### PR TITLE
Ensure manifest v3 extensions aren't removed between tests

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "cypress",
-  "version": "10.9.0",
+  "version": "10.9.1-klarna.1",
   "description": "Cypress.io end to end testing tool",
   "private": true,
   "scripts": {

--- a/packages/example/package.json
+++ b/packages/example/package.json
@@ -28,7 +28,7 @@
   "devDependencies": {
     "chai": "3.5.0",
     "cross-env": "6.0.3",
-    "cypress-example-kitchensink": "https://github.com/cypress-io/cypress-example-kitchensink.git#994a943b76f1186c10ce083f48266cee2f76aeb4",
+    "cypress-example-kitchensink": "https://github.com/cypress-io/cypress-example-kitchensink.git#ab10094ef7b199ae7febafec413a0626414bcd3c",
     "gulp": "4.0.2",
     "gulp-clean": "0.4.0",
     "gulp-gh-pages": "0.6.0-6",

--- a/packages/server/lib/browsers/cdp_automation.ts
+++ b/packages/server/lib/browsers/cdp_automation.ts
@@ -381,7 +381,8 @@ export class CdpAutomation {
         })
       case 'reset:browser:state':
         return Promise.all([
-          this.sendDebuggerCommandFn('Storage.clearDataForOrigin', { origin: '*', storageTypes: 'all' }),
+          // https://github.com/cypress-io/cypress/issues/25408
+          this.sendDebuggerCommandFn('Storage.clearDataForOrigin', { origin: '*', storageTypes: 'appcache,cookies,file_systems,indexeddb,local_storage,shader_cache,websql,cache_storage,interest_groups,shared_storage' }),
           this.sendDebuggerCommandFn('Network.clearBrowserCache'),
         ])
       case 'reset:browser:tabs:for:next:test':

--- a/yarn.lock
+++ b/yarn.lock
@@ -13582,9 +13582,9 @@ cypress-each@^1.11.0:
   resolved "https://registry.yarnpkg.com/cypress-each/-/cypress-each-1.11.0.tgz#013c9b43a950f157bcf082d4bd0bb424fb370441"
   integrity sha512-zeqeQkppPL6BKLIJdfR5IUoZRrxRudApJapnFzWCkkrmefQSqdlBma2fzhmniSJ3TRhxe5xpK3W3/l8aCrHvwQ==
 
-"cypress-example-kitchensink@https://github.com/cypress-io/cypress-example-kitchensink.git#994a943b76f1186c10ce083f48266cee2f76aeb4":
+"cypress-example-kitchensink@https://github.com/cypress-io/cypress-example-kitchensink.git#ab10094ef7b199ae7febafec413a0626414bcd3c":
   version "0.0.0-development"
-  resolved "https://github.com/cypress-io/cypress-example-kitchensink.git#994a943b76f1186c10ce083f48266cee2f76aeb4"
+  resolved "https://github.com/cypress-io/cypress-example-kitchensink.git#ab10094ef7b199ae7febafec413a0626414bcd3c"
   dependencies:
     npm-run-all "^4.1.2"
     serve "11.3.0"


### PR DESCRIPTION
Closes https://github.com/cypress-io/cypress/issues/25408

TODO: 
- [x] `yarn binary-build --skipSigning`
- [x] Create GH release: [10.9.1-klarna.1](https://github.com/eps1lon/cypress/releases/tag/v10.9.1-klarna.1)
- [x] Attach built binaries to GH release
- [x] [Test in Klarna CI](https://stash.int.klarna.net/projects/KLAPP/repos/klarna-app/pull-requests/122724/builds)